### PR TITLE
Make opensearch index async to avoid blocking DB operations

### DIFF
--- a/opensearch_reports/service.py
+++ b/opensearch_reports/service.py
@@ -55,5 +55,5 @@ class BaseSyncDocument(Document):
                 )
         else:
             # Log and skip bulk syncing if disabled
-            logger.info(f"Bulk sync is disabled for index '{self._index._name}'")
+            logger.info(f"Skipping bulk sync because sync is disabled for dashboard '{self.DASHBOARD_NAME}'")
             return None

--- a/opensearch_reports/service.py
+++ b/opensearch_reports/service.py
@@ -6,6 +6,7 @@ from core.services import BaseService
 from core.signals import register_service_signal
 from opensearch_reports.models import OpenSearchDashboard
 from opensearch_reports.validations import OpenSearchDashboardValidation
+from opensearch_reports.tasks import index_opensearch_bulk
 
 logger = logging.getLogger(__name__)
 
@@ -38,24 +39,20 @@ class BaseSyncDocument(Document):
             # If no dashboard entry, assume sync is enabled
             return False
 
-    def update(self, thing, action, *args, refresh=None, using=None, **kwargs):
-        """
-        Override the update method to control synchronization dynamically.
-        """
-        if not self.is_sync_disabled():
-            # Proceed with normal update if sync is not disabled
-            return super().update(thing, action, *args, refresh=refresh, using=using, **kwargs)
-        else:
-            # Log and skip syncing if disabled
-            logger.info(f"Sync is disabled for index '{self._index._name}'")
-            return None
-
-    def bulk(self, actions, using=None, **kwargs):
+    def bulk(self, actions, using=None, from_celery=False, **kwargs):
         """
         Override the bulk method to control batch synchronization dynamically.
+        Document.update() uses bulk()
         """
         if not self.is_sync_disabled():
-            return super().bulk(actions, using=using, **kwargs)
+            if from_celery:
+                return super().bulk(actions, using=using, **kwargs)
+            else:
+                model = self.Django.model
+                app_label = model._meta.app_label
+                index_opensearch_bulk.delay(
+                    app_label, model.__name__, list(actions), using=using, **kwargs
+                )
         else:
             # Log and skip bulk syncing if disabled
             logger.info(f"Bulk sync is disabled for index '{self._index._name}'")

--- a/opensearch_reports/tasks.py
+++ b/opensearch_reports/tasks.py
@@ -1,0 +1,24 @@
+import logging
+
+from celery import shared_task
+from django.apps import apps
+from django_opensearch_dsl.registries import registry
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task
+def index_opensearch_bulk(app_label, model_name, actions, using=None, **kwargs):
+    for doc in _get_documents(app_label, model_name):
+        doc.bulk(iter(actions), using=using, from_celery=True, **kwargs)
+
+
+def _get_documents(app_label, model_name):
+    Model = apps.get_model(app_label, model_name)
+    document_classes = registry._models[Model]
+    if not document_classes:
+        logger.warning(f"No OpenSearch document found for model: {model_name} in app: {app_label}")
+        return
+
+    for doc_class in document_classes:
+        yield doc_class()

--- a/opensearch_reports/tests.py
+++ b/opensearch_reports/tests.py
@@ -1,3 +1,0 @@
-from django.test import TestCase
-
-# Create your tests here.

--- a/opensearch_reports/tests/test_service.py
+++ b/opensearch_reports/tests/test_service.py
@@ -1,0 +1,87 @@
+from core.models import MutationLog
+from core.test_helpers import create_test_interactive_user
+from django.test import TestCase, override_settings
+from django_opensearch_dsl.registries import registry, DODConfig
+from django_opensearch_dsl.documents import Document
+from django_opensearch_dsl.registries import registry
+from unittest.mock import patch
+from opensearchpy import OpenSearch
+
+from opensearch_reports.models import OpenSearchDashboard
+from opensearch_reports.service import BaseSyncDocument
+
+
+class MutationLogDocument(BaseSyncDocument):
+    DASHBOARD_NAME = 'MutationLog'
+
+    class Index:
+        name = "mutation_log_index"
+        auto_refresh = True
+
+    class Django:
+        model = MutationLog
+        fields = ["json_content"]
+        ignore_signals = False
+
+
+@override_settings(task_always_eager=True, task_eager_propagates=True)
+class BaseSyncDocumentTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = create_test_interactive_user(username="admin")
+        registry.register_document(MutationLogDocument)
+        cls.dashboard = OpenSearchDashboard(
+            name=MutationLogDocument.DASHBOARD_NAME,
+            synch_disabled=False,
+            url='http://localhost/opensearch'
+        )
+        cls.dashboard.save(username=cls.user.username)
+
+    @patch.object(Document, "bulk")
+    def test_auto_refresh_sync_enabled(self, mock_doc_bulk):
+        log = MutationLog.objects.create(json_content='foobar')
+
+        mock_doc_bulk.assert_called()
+
+        # Ensure the correct instance is being indexed
+        actions = mock_doc_bulk.call_args[0][0]  # First positional argument
+        action = next(actions)
+        self.assertEqual(action['_id'], log.pk)
+        self.assertEqual(action['_op_type'], 'index')
+
+        kwargs = mock_doc_bulk.call_args[1]
+        self.assertTrue('refresh' in kwargs)
+        self.assertTrue(kwargs['refresh'])
+
+    @patch.object(Document, "bulk")
+    def test_auto_refresh_sync_disabled(self, mock_doc_bulk):
+        # Disable sync
+        self.dashboard.synch_disabled = True
+        self.dashboard.save(username=self.user.username)
+
+        log = MutationLog.objects.create(json_content='foobarbaz')
+
+        # Indexing should NOT proceed because sync is disabled
+        mock_doc_bulk.assert_not_called()
+
+    @patch.object(Document, "bulk")
+    def test_bulk_update(self, mock_doc_bulk):
+        log1 = MutationLog(json_content='log1')
+        log2 = MutationLog(json_content='log2')
+        MutationLog.objects.bulk_create([log1, log2])
+        logs = MutationLog.objects.filter(json_content__contains='log')
+
+        MutationLogDocument().update(logs, 'index')
+
+        mock_doc_bulk.assert_called()
+
+        actions = list(mock_doc_bulk.call_args[0][0])
+        sorted_ids = sorted(action['_id'] for action in actions)
+        expected_ids = sorted(logs.values_list('pk', flat=True))
+        self.assertEqual(sorted_ids, expected_ids)
+
+        kwargs = mock_doc_bulk.call_args[1]
+        self.assertTrue('refresh' in kwargs)
+        self.assertTrue(kwargs['refresh'])


### PR DESCRIPTION
This way, failed indexing would not prevent/rollback DB persistence. It would also speed up bulk operations such as individuals import