### PR TITLE
feat: authorize OpenSearch Dashboards access against openIMIS rights

### DIFF
--- a/opensearch_reports/tests/test_auth_check.py
+++ b/opensearch_reports/tests/test_auth_check.py
@@ -1,0 +1,93 @@
+from unittest.mock import patch
+
+from core.test_helpers import create_test_interactive_user, create_test_role
+from django.test import TestCase
+from graphql_jwt.settings import jwt_settings
+from graphql_jwt.shortcuts import get_token
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from opensearch_reports.apps import OpensearchReportsConfig
+
+AUTH_CHECK_URL = '/api/opensearch_reports/auth_check'
+
+
+class OpenSearchAuthCheckTest(TestCase):
+    """Status contract the nginx auth_request depends on: 200 authorized,
+    401 no usable credential (nginx redirects to login), 403 not allowed."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.role_read = create_test_role(
+            ['gql_opensearch_dashboard_search_perms'], name='OpenSearchViewer'
+        )
+        cls.role_without_right = create_test_role([], name='NoOpenSearchAccess')
+        cls.user_allowed = create_test_interactive_user(
+            username='os_allowed', roles=[cls.role_read.id]
+        )
+        cls.user_denied = create_test_interactive_user(
+            username='os_denied', roles=[cls.role_without_right.id]
+        )
+
+    def _client_for(self, user):
+        """Authenticate as the browser does: JWT cookie only, no Authorization
+        header, since that is all nginx forwards."""
+        client = APIClient()
+        client.cookies[jwt_settings.JWT_COOKIE_NAME] = get_token(user)
+        return client
+
+    def test_anonymous_request_is_401(self):
+        response = APIClient().get(AUTH_CHECK_URL)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_invalid_token_is_401(self):
+        client = APIClient()
+        client.cookies[jwt_settings.JWT_COOKIE_NAME] = 'not-a-jwt'
+
+        response = client.get(AUTH_CHECK_URL)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_token_whose_user_is_gone_is_401(self):
+        # A removed user keeps a usable cookie until it expires.
+        client = self._client_for(self.user_allowed)
+
+        with patch('core.jwt_authentication.get_user_by_token', return_value=None):
+            response = client.get(AUTH_CHECK_URL)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_user_without_dashboard_right_is_403(self):
+        response = self._client_for(self.user_denied).get(AUTH_CHECK_URL)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_with_dashboard_right_is_200(self):
+        response = self._client_for(self.user_allowed).get(AUTH_CHECK_URL)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_unconfigured_rights_deny(self):
+        with patch.object(OpensearchReportsConfig,
+                          'gql_opensearch_dashboard_search_perms', None):
+            response = self._client_for(self.user_allowed).get(AUTH_CHECK_URL)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        with patch.object(OpensearchReportsConfig,
+                          'gql_opensearch_dashboard_search_perms', []):
+            response = self._client_for(self.user_allowed).get(AUTH_CHECK_URL)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_check_issues_no_outbound_http(self):
+        # nginx invokes this once per Dashboards request, so it must not call out.
+        with patch('urllib3.connectionpool.HTTPConnectionPool.urlopen') as pool, \
+                patch('requests.Session.request') as session:
+            response = self._client_for(self.user_allowed).get(AUTH_CHECK_URL)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        pool.assert_not_called()
+        session.assert_not_called()

--- a/opensearch_reports/urls.py
+++ b/opensearch_reports/urls.py
@@ -1,1 +1,7 @@
-urlpatterns = []
+from django.urls import path
+
+from opensearch_reports import views
+
+urlpatterns = [
+    path("auth_check", views.opensearch_auth_check),
+]

--- a/opensearch_reports/views.py
+++ b/opensearch_reports/views.py
@@ -1,3 +1,51 @@
-# from django.shortcuts import render
+import logging
 
-# Create your views here.
+from core.jwt_authentication import JWTAuthentication
+from django.http import HttpResponse
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
+from rest_framework.permissions import AllowAny
+
+from opensearch_reports.apps import OpensearchReportsConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _has_rights(user, rights):
+    """Deny when nothing is configured: has_perms returns True for an empty list."""
+    if not rights:
+        return False
+    return user.has_perms(rights)
+
+
+@api_view(["GET", "HEAD"])
+@authentication_classes([JWTAuthentication])
+@permission_classes([AllowAny])
+def opensearch_auth_check(request):
+    """Authorize Dashboards access for the current user, for nginx auth_request.
+
+    Runs once per Dashboards request, so it stays a database rights lookup with
+    no outbound calls. Credentials arrive as the openIMIS JWT cookie.
+
+    Only the status is consumed: 200 authorized, 403 authenticated but not
+    allowed, 401 no usable credential - which nginx turns into a login redirect.
+    Authentication is checked here rather than through IsAuthenticated so that
+    every unauthenticated path answers 401, a valid cookie for a removed user
+    included.
+    """
+    if not request.user or not request.user.is_authenticated:
+        return HttpResponse(status=401)
+
+    rights = OpensearchReportsConfig.gql_opensearch_dashboard_search_perms
+    if not _has_rights(request.user, rights):
+        logger.debug(
+            "Dashboards access denied for %s: missing right(s) %s",
+            request.user.username,
+            rights,
+        )
+        return HttpResponse(status=403)
+
+    return HttpResponse(status=200)


### PR DESCRIPTION
## Problem

Dashboards is reachable by **any authenticated openIMIS user**, regardless of rights. The nginx gate in `openimis-fe_js` runs `auth_request /check_user/`, which resolves to `core/users/current_user/` — permission `IsAuthenticated` only. Measured against `develop`: a logged-in user whose roles carry neither dashboard right gets **200** and reads every index, including insuree and claim data.

## Change

A dedicated authorization endpoint for the reverse proxy to call:

`GET /<site_root>/opensearch_reports/auth_check`

| Status | Meaning |
|---|---|
| 200 | holds `gql_opensearch_dashboard_search_perms` (`199001`) |
| 403 | authenticated, right missing |
| 401 | no usable credential — the proxy turns this into a login redirect |

Credentials arrive as the openIMIS JWT cookie: `core.jwt_authentication.JWTAuthentication` already accepts one through graphql_jwt's cookie fallback in `get_credentials`, so no new authentication code. The check is a database rights lookup with **no outbound calls** — it runs once per Dashboards request.

## Notes for reviewers

- **Fail-closed on an unset config.** `core.models.User.has_perms` returns `True` for an empty list, so passing the config straight through would open the gate to every authenticated user if `gql_opensearch_dashboard_search_perms` were unset. `_has_rights` rejects that explicitly.
- **401 rather than 403 for unauthenticated requests** matters: nginx's `error_page 401` is the only thing that can start a login flow. Authentication is checked in the view rather than by `IsAuthenticated` so that a valid cookie for a removed user also answers 401 instead of 403.
- **No read/write distinction, deliberately.** Dashboards uses POST for reads — including the `/api/core/capabilities` call it cannot start without — so the HTTP method says nothing about intent. `gql_opensearch_dashboard_update_perms` stays unused; restricting writes needs the OpenSearch security plugin, which sees actual index operations.

## Tests

10 tests, `manage.py test opensearch_reports` — anonymous 401, malformed token 401, valid token for a removed user 401, right held 200, right missing 403, unset/empty rights config 403, and a guard that the check issues no outbound HTTP (patching both urllib3 and requests).

Paired with the `openimis-fe_js` PR that repoints the gate; that one must land after this, since it 401s until this endpoint exists.
